### PR TITLE
Fix inaccurate examples

### DIFF
--- a/practices/dateTimeFormatString/best_practice.md
+++ b/practices/dateTimeFormatString/best_practice.md
@@ -58,7 +58,7 @@ Valid date time formats are a combination of date, time, and timezone strings.
 
 #### Rules for combining date, time, and timezone:
 
-If reporting a date without time, select one of the date format strings. If reporting a date and time, select one date and one time format string and combine with a single space (e.g. "YYYY-MM-DD hh:mm:ss") or with a "T" (e.g. "YYYY-MM-DDThh:mm:ss"). If reporting a date and time, it is recommended that a time zone specifier be appended without a space (e.g.  "YYYY-MM-DDThh:mm-hh:mmZ"). Time zone "Z" denotes UTC, and time zone "+" or "-" are times ahead and behind UTC, respectively (e.g. "YYYY-MM-DDThh:mm-hh:mm-07:00").
+If reporting a date without time, select one of the date format strings. If reporting a date and time, select one date and one time format string and combine with a single space (e.g. "YYYY-MM-DD hh:mm:ss") or with a "T" (e.g. "YYYY-MM-DDThh:mm:ss"). If reporting a date and time, it is recommended that a time zone specifier be appended without a space (e.g.  "YYYY-MM-DDThh:mm-hh:mm"). Time zone "Z" denotes UTC, and time zone "+" or "-" are times ahead and behind UTC, respectively.
 
 #### Examples of dateTime/formatStrings and congruence:
 |Format string (metadata)|Compliant data value |Non compliant data values|


### PR DESCRIPTION
Two inaccuracies are being fixed here:

1.) The time zone offset should not be followed by a "Z" (e.g. "YYYY-MM-DDThh:mm-hh:mmZ" is incorrect; "YYYY-MM-DDThh:mm-hh:mm" is correct). Note that appending "Z" to a time indicates it is in UTC (e.g. YYYY-MM-DDThh:mmZ) and is correct.

2.) The example "YYYY-MM-DDThh:mm-hh:mm-07:00" doesn't make any sense and is syntactically incorrect.