### PR TITLE
Fix rendering of example date/time formats

### DIFF
--- a/code/format_string_builder.py
+++ b/code/format_string_builder.py
@@ -114,11 +114,10 @@ def generate_example_date(format_string: str) -> str:
         "-hh": "-07"
     }
 
-    result = None
     for key, value in example_date_time.items():
-        result = format_string.replace(key, value)
+        format_string = format_string.replace(key, value)
 
-    return result
+    return format_string
 
 
 def write_to_csv(formats: list, file_path: str) -> None:


### PR DESCRIPTION
Fix the rendering of example date/time formats. Faulty code logic is preventing the strings from being generated correctly.

Related to 0b5b7365a109adeb59e8e58b5aa5cf12de31fd80