### PR TITLE
Add .gitignore entry for PyCharm .idea files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@
 ehthumbs.db
 Thumbs.db
 
+# Pycharm specific files
+.idea/
+


### PR DESCRIPTION
Add `.idea/` to `.gitignore` to prevent PyCharm project files from being tracked.